### PR TITLE
ci: pin golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.11.4


### PR DESCRIPTION
golangci-lint's "latest" resolution auto-upgraded to v2.12.x, whose goconst linter began aggregating string counts across test files, failing previously-clean code. Pinning avoids unplanned CI breaks from future upstream releases.